### PR TITLE
fix: update IP address, location, timezone, and ISP html tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,9 +68,9 @@
               <p
                 class="text-[hsl(0,0%,59%)] text-center xl:text-left font-[700] uppercase text-xs xl:text-[0.85rem] leading-none tracking-[0.08rem] pb-2">
                 IP Address</p>
-              <h3
+              <p
                 class="text-[hsl(0,0%,17%)] text-center xl:text-left font-[500] text-[1.4rem] xl:text-[26px] leading-tight"
-                id="search__info_ip">192.212.174.101</h3>
+                id="search__info_ip">192.212.174.101</p>
             </div>
 
             <div
@@ -78,10 +78,10 @@
               <p
                 class="text-[hsl(0,0%,59%)] text-center xl:text-left font-[700] uppercase text-xs xl:text-[0.85rem] leading-none tracking-[0.08rem] pb-2">
                 Location</p>
-              <h3
+              <p
                 class="text-[hsl(0,0%,17%)] text-center xl:text-left font-[500] text-[1.4rem] xl:text-[26px] leading-tight"
                 id="search__info_location">Brooklyn, NY 10001
-              </h3>
+              </p>
             </div>
 
             <div
@@ -89,9 +89,9 @@
               <p
                 class="text-[hsl(0,0%,59%)] text-center xl:text-left font-[700] uppercase text-xs xl:text-[0.85rem] leading-none tracking-[0.08rem] pb-2">
                 Timezone</p>
-              <h3
+              <p
                 class="text-[hsl(0,0%,17%)] text-center xl:text-left font-[500] text-[1.4rem] xl:text-[26px] leading-tight"
-                id="search__info_timezone">UTC -5:00</h3>
+                id="search__info_timezone">UTC -5:00</p>
             </div>
 
             <div
@@ -99,9 +99,9 @@
               <p
                 class="text-[hsl(0,0%,59%)] text-center xl:text-left font-[700] uppercase text-xs xl:text-[0.85rem] leading-none tracking-[0.08rem] pb-2">
                 ISP</p>
-              <h3
+              <p
                 class="text-[hsl(0,0%,17%)] text-center xl:text-left font-[500] text-[1.4rem] xl:text-[26px] leading-tight"
-                id="search__info_isp">SpaceX Starlink</h3>
+                id="search__info_isp">SpaceX Starlink</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
- Updated the HTML markup to use p tags instead of h3 tags for displaying the IP address, location, timezone, and ISP information.
- This change improves accessibility and adheres to best practices for semantic HTML.

Fixes:
-  #8