### PR TITLE
fix: update HTML markup tag for map container

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,16 +108,16 @@
       </div>
     </section>
 
-    <section id="map-ctn" class="h-full">
-    </section>
+    <div role="mapBox" id="map-ctn" class="h-full">
+    </div>
   </main>
 
 
-  <div class="text-[11px] text-center [&_a]:text-[hsl(228,45%,44%)]">
+  <footer class="text-[11px] text-center [&_a]:text-[hsl(228,45%,44%)]">
     Challenge by
     <a href="https://www.frontendmentor.io?ref=challenge" target="_blank">Frontend Mentor</a>. Coded by
     <a href="https://www.github.com/abdulazeezoj">Abdulazeez Jimoh</a>.
-  </div>
+  </footer>
 
   <!-- JS -->
   <script src="./index.js"></script>


### PR DESCRIPTION
Updated the HTML markup for the map container to use a `<div>` element with the role attribute instead of an empty `<section>` element. This change improves accessibility and adheres to best practices for semantic HTML.

Fixes: #9