### PR TITLE
fix: update HTML markup for map container

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,8 +68,7 @@
               <p
                 class="text-[hsl(0,0%,59%)] text-center xl:text-left font-[700] uppercase text-xs xl:text-[0.85rem] leading-none tracking-[0.08rem] pb-2">
                 IP Address</p>
-              <p
-                class="text-[hsl(0,0%,17%)] text-center xl:text-left font-[500] text-[1.4rem] xl:text-[26px] leading-tight"
+              <p class="text-[hsl(0,0%,17%)] text-center xl:text-left font-[500] text-[1.4rem] xl:text-[26px] leading-tight"
                 id="search__info_ip">192.212.174.101</p>
             </div>
 
@@ -78,8 +77,7 @@
               <p
                 class="text-[hsl(0,0%,59%)] text-center xl:text-left font-[700] uppercase text-xs xl:text-[0.85rem] leading-none tracking-[0.08rem] pb-2">
                 Location</p>
-              <p
-                class="text-[hsl(0,0%,17%)] text-center xl:text-left font-[500] text-[1.4rem] xl:text-[26px] leading-tight"
+              <p class="text-[hsl(0,0%,17%)] text-center xl:text-left font-[500] text-[1.4rem] xl:text-[26px] leading-tight"
                 id="search__info_location">Brooklyn, NY 10001
               </p>
             </div>
@@ -89,8 +87,7 @@
               <p
                 class="text-[hsl(0,0%,59%)] text-center xl:text-left font-[700] uppercase text-xs xl:text-[0.85rem] leading-none tracking-[0.08rem] pb-2">
                 Timezone</p>
-              <p
-                class="text-[hsl(0,0%,17%)] text-center xl:text-left font-[500] text-[1.4rem] xl:text-[26px] leading-tight"
+              <p class="text-[hsl(0,0%,17%)] text-center xl:text-left font-[500] text-[1.4rem] xl:text-[26px] leading-tight"
                 id="search__info_timezone">UTC -5:00</p>
             </div>
 
@@ -99,8 +96,7 @@
               <p
                 class="text-[hsl(0,0%,59%)] text-center xl:text-left font-[700] uppercase text-xs xl:text-[0.85rem] leading-none tracking-[0.08rem] pb-2">
                 ISP</p>
-              <p
-                class="text-[hsl(0,0%,17%)] text-center xl:text-left font-[500] text-[1.4rem] xl:text-[26px] leading-tight"
+              <p class="text-[hsl(0,0%,17%)] text-center xl:text-left font-[500] text-[1.4rem] xl:text-[26px] leading-tight"
                 id="search__info_isp">SpaceX Starlink</p>
             </div>
           </div>
@@ -108,7 +104,8 @@
       </div>
     </section>
 
-    <div role="mapBox" id="map-ctn" class="h-full">
+    <div role="section" aria-label="Map container" id="map-ctn" class="h-full">
+      <p>Your browser does not support maps. The map shows...</p>
     </div>
   </main>
 


### PR DESCRIPTION
Improve accessibility and adhere to best practices by updating the HTML markup for the map container. Replace the empty `<section>` element with a `<div>` element with the role attribute.

Fixes: #15